### PR TITLE
archive lab

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+repository:
+  name: umbra
+  archived: true


### PR DESCRIPTION
Archived labs are read-only, and they can be moved back out of the archives, if there is interest in reviving them.

Signed-off-by: Ry Jones <ry@linux.com>